### PR TITLE
doc: Be explicit about parameters, and link COSE algorithms

### DIFF
--- a/src/ccm.rs
+++ b/src/ccm.rs
@@ -31,6 +31,13 @@ impl CcmTagSize for U14 {}
 impl CcmTagSize for U16 {}
 
 /// The AES-CCM instance.
+///
+/// This is currently fixed to 128-bit keys and 13-byte nonces (and thus limited to 64KiB
+/// messages), and generic over tag sizes.
+///
+/// In terms of [COSE](https://tools.ietf.org/html/rfc8152#section-10.2), it implements
+/// AES-CCM-16-x-128, with x being the TagSize in bits. That is, `AesCcm<U8>` implements
+/// AES-CCM-16-64-128, and `AesCcm<U16>` imlements AES-CCM-16-128-128.
 pub struct AesCcm<TagSize>
 where
     TagSize: CcmTagSize,


### PR DESCRIPTION
While the parameters of AES-CCM are encoded in the types of the NewAead
and Aead implementations, those are not visible by default and sometimes
not given in the common unit of bits. This adds explicit text
documentation that makes those visible.

In addition, the equivalent COSE algorithms are stated; this is useful
because their parameterization is in terms of log(maximum message size),
while the Aead parameters are given in terms of nonce size. Mentioning
the two relevant versions explicitly makes them easier to discover in
generic full-text search.

---

I've considered linking this to TLS algorithms as well, but all I found there had nonce sizes of 12, so I'm not sure this is parameterized flexibly enough to even be usable for that purpose; as I'm not deeply familiar enough with TLS to be sure that their 12 byte nonce would need to fit our 13 byte nonce, I refrained from adding a statement like "The TLS AES-CCM algorithms AEAD_AES_128_CCM and AEAD_AES_128_CCM_8 can not be served by this, as they expect to use 12 byte nonces" (but it might make sense to add it if it is true).