### PR TITLE
Upgrade `aead` crate dependency to v0.3; MSRV 1.41+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-aead = { version = "0.2", default-features = false }
-aes = "0.3.2"
+aead = { version = "0.3", default-features = false }
+aes = "0.4.0"
 subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
@@ -28,6 +28,3 @@ hex-literal = "0.2.0"
 default = ["alloc"]
 alloc = ["aead/alloc"]
 heapless = ["aead/heapless"]
-
-[badges]
-maintenance = { status = "passively-maintained" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! ## Usage
 //! ```rust
 //! use aes_ccm::{
-//!     aead::{generic_array::typenum::U8, Aead, NewAead, Payload},
+//!     aead::{consts::U8, Aead, NewAead, Payload},
 //!     AesCcm,
 //! };
 //!
@@ -31,7 +31,7 @@
 //! ];
 //!
 //! // `U8` represents the tag size as a `typenum` unsigned (8-bytes here)
-//! let ccm = AesCcm::<U8>::new(key.into());
+//! let ccm = AesCcm::<U8>::new(&key.into());
 //!
 //! let nonce = [
 //!     0x00, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0xA0, 0xA1, 0xA2, 0xA3,
@@ -82,11 +82,13 @@
 //! and decrypt methods:
 //!
 //! ```rust
+//! # #[cfg(feature = "heapless")]
+//! # {
 //! use aes_ccm::{
 //!     aead::{
-//!         generic_array::typenum::{U128, U8},
+//!         consts::{U128, U8},
 //!         heapless::Vec,
-//!         Aead, NewAead,
+//!         AeadInPlace, NewAead,
 //!     },
 //!     AesCcm,
 //! };
@@ -97,7 +99,7 @@
 //! ];
 //!
 //! // `U8` represents the tag size as a `typenum` unsigned (8-bytes here)
-//! let ccm = AesCcm::<U8>::new(key.into());
+//! let ccm = AesCcm::<U8>::new(&key.into());
 //!
 //! let nonce = [
 //!     0x00, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0xA0, 0xA1, 0xA2, 0xA3,
@@ -125,6 +127,7 @@
 //! ccm.decrypt_in_place(&nonce.into(), &associated_data, &mut buffer)
 //!     .unwrap();
 //! assert_eq!(&buffer, &plaintext);
+//! # }
 //! ```
 //!
 //! ## Security


### PR DESCRIPTION
There's a new release of the `aead` crate out which bumps the `generic-array` dependency to v0.14, which has an MSRV of 1.41+.

It additionally makes the following changes:

- `NewAead` now borrows the key, preventing unnecessary copies
- The in-place methods of the `Aead` trait have now been split into a separate `AeadInPlace` trait, with a blanket impl of the former for the latter

This commit also bumps the `aes` dependency to one which uses the new `block-cipher` crate (renamed from `block-cipher-traits`), which also uses `generic-array` v0.14 and splits out the `NewBlockCipher` trait from the `BlockCipher` trait, which is helpful for implementations using hardware-backed keys.